### PR TITLE
corrected typo

### DIFF
--- a/utilities/bash/mad6t.sh
+++ b/utilities/bash/mad6t.sh
@@ -171,7 +171,7 @@ function check(){
 	sixdeskmess
 	sixdeskmess="If these messages are annoying you and you have checked them carefully then"
 	sixdeskmess
-	sixdeskmess="just remove sixtrack_input/ERRORS or rm sixtrack_input/* and rerun `basname $0` -s!"
+	sixdeskmess="just remove sixtrack_input/ERRORS or rm sixtrack_input/* and rerun `basename $0` -s!"
 	sixdeskmess
 	echo "ERRORS"
 	cat $sixtrack_input/ERRORS


### PR DESCRIPTION
under certain conditions running mad6t delivered the following error message:

`/afs/cern.ch/work/p/phermes/private/SixDesk/utilities/bash/mad6t.sh: line 174: basname: command not found`
 
corrected by substituting with basename