### PR TITLE
Better naming of condor jobs and script to wait for completion

### DIFF
--- a/utilities/bash/condor_wait.sh
+++ b/utilities/bash/condor_wait.sh
@@ -11,7 +11,7 @@ while getopts "h?n:i:sv" opt; do
   h|\?)
     echo "Usage: $0 [-n batch name] [-i interval in seconds] [-s[s really] silent] [-v verbose]"
     echo
-    echo "The batch name when given filters the condor_q output. Example:"
+    echo "The batch name (when given) filters the condor_q output. Example:"
     echo " $0 -n mad/MY_WORKSPACE/ -i 60"
     exit 0
     ;;

--- a/utilities/bash/condor_wait.sh
+++ b/utilities/bash/condor_wait.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+bname="ALL"
+interval=600
+verb=2
+NEWLINE=$'\n'
+
+OPTIND=1
+while getopts "h?n:i:sv" opt; do
+  case "$opt" in
+  h|\?)
+    echo "Usage: $0 [-n batch name] [-i interval in seconds] [-s[s really] silent] [-v verbose]"
+    echo
+    echo "The batch name when given filters the condor_q output. Example:"
+    echo " $0 -n mad/MY_WORKSPACE/ -i 60"
+    exit 0
+    ;;
+  n)  bname=$OPTARG
+    ;;
+  i)  interval=$OPTARG
+    ;;
+  s)  ((verb--))
+    ;;
+  v)  ((verb++))
+    ;;
+  esac
+done
+
+function msg () {
+  if [ $verb -ge $1 ]; then
+    echo "$(date) --> $2"
+  fi
+}
+
+msg 1 "Waiting for jobs named $bname to complete. Querying every $interval seconds..."
+
+while
+  while
+    cq="$(condor_q)"
+    [ $? -ne 0 ]
+  do
+    msg 1 "Warning condor_q did not return zero..."
+    sleep 5
+  done
+  j="$(echo "$cq" | tail -n +5 | head -n -3 )"
+  if [ "$bname" != "ALL" ]; then
+    j="$(echo "$j" | grep $bname)"
+  fi
+
+  if [[ -z $j ]]; then
+    q_jobs=0
+  else
+    q_jobs=$(echo "$j" | wc -l)
+  fi
+  [ $q_jobs -gt 0 ]
+do
+  msg 3 "${NEWLINE}$(echo "$cq" | head -4 | tail -1)${NEWLINE}$j"
+  msg 2 "Number of batches in the cluster: $q_jobs"
+  sleep $interval
+done
+
+msg 1 "No more jobs!"

--- a/utilities/bash/mad6t.sh
+++ b/utilities/bash/mad6t.sh
@@ -179,7 +179,7 @@ function submit(){
     if [ "$sixdeskplatform" == "htcondor" ] && ! ${linter} ; then
 	cp ${SCRIPTDIR}/templates/htcondor/mad6t.sub .
 	sed -i "s#^+JobFlavour =.*#+JobFlavour = \"${madHTCq}\"#" mad6t.sub
-	condor_submit mad6t.sub
+	condor_submit -batch-name "mad/$workspace/$LHCDescrip" mad6t.sub
 	if [ $? -eq 0 ] ; then
 	    rm -f jobs.list
 	fi

--- a/utilities/bash/run_six.sh
+++ b/utilities/bash/run_six.sh
@@ -2360,11 +2360,12 @@ if ${lsubmit} ; then
 	    rm -f ${sixdeskjobs}/${LHCDesName}.list
 	else
 	    cd ${sixdesktrack}
-	    sixdeskmess -1 "Submitting jobs to $sixdeskplatform from dir $PWD"
+            batch_name="run_six/$workspace/$LHCDescrip"
+	    sixdeskmess -1 "Submitting jobs to $sixdeskplatform from dir $PWD \"$batch_name\""
 	    sixdeskmess  1 "Depending on the number of points in the scan, this operation can take up to few minutes."
 	    allCases=`cat ${sixdeskjobs}/${LHCDesName}.list`
 	    allCases=( ${allCases} )
-	    multipleTrials "terseString=\"\`condor_submit -terse ${sixdeskjobs}/htcondor_run_six.sub\`\" " "[ -n \"\${terseString}\" ]" "Problem at condor_submit"
+	    multipleTrials "terseString=\"\`condor_submit -batch-name ${batch_name} -terse ${sixdeskjobs}/htcondor_run_six.sub\`\" " "[ -n \"\${terseString}\" ]" "Problem at condor_submit"
 	    let __lerr+=$?
 	    if [ ${__lerr} -ne 0 ] ; then
 		sixdeskmess -1 "Something wrong with htcondor submission: submission didn't work properly - exit status: ${__lerr}"


### PR DESCRIPTION
Condor batch jobs are now named:

mad/MY_WORKSPACE/MY_STUDY
run_six/MY_WORKSPACE/MY_STUDY

condor_wait.sh allows for periodically checking the condor queue and returns when all the jobs are completed.


--------------------------
This is how condor_q now looks like:

```
$ condor_q
-- Schedd: bigbird02.cern.ch : <128.142.196.38:9618?... @ 06/09/17 13:16:04
OWNER    BATCH_NAME                                   SUBMITTED   DONE   RUN    IDLE  TOTAL JOB_IDS
dpellegr mad/WireIS_X120_L/ats2017wire_-250_16       6/9  12:57      _      1      _      1 305408.0
dpellegr run_six/WireIS_X120_R/ats2017wire_-100_08   6/9  12:57      _     20      _     20 305410.0-19
dpellegr mad/WireIS_X120_L/ats2017wire_-250_18       6/9  12:58      _      1      _      1 305411.0
dpellegr mad/WireIS_X120_L/ats2017wire_-250_19       6/9  12:58      _      1      _      1 305412.0
dpellegr mad/WireIS_X120_L/ats2017wire_-250_20       6/9  12:58      _      1      _      1 305413.0
dpellegr mad/WireIS_X120_L/ats2017wire_-200_04       6/9  12:58      _      1      _      1 305414.0
dpellegr mad/WireIS_X120_L/ats2017wire_-200_05       6/9  12:58      _      1      _      1 305415.0
dpellegr run_six/WireIS_X120_R/ats2017wire_-100_09   6/9  12:58      _      _     20     20 305416.0-19
```
...