### PR TITLE
added scan functions

### DIFF
--- a/utilities/bash/scan_correct_cases
+++ b/utilities/bash/scan_correct_cases
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+source ./scan_definitions
+source ./sixdeskenv
+
+
+# ------------------------------------------------------------------------------
+# preparatory steps
+# ------------------------------------------------------------------------------
+
+export sixdeskhostname=`hostname`
+export sixdeskname=`basename $0`
+export sixdeskroot=`basename $PWD`
+export sixdeskwhere=`dirname $PWD`
+# Set up some temporary values until we execute sixdeskenv/sysenv
+# Don't issue lock/unlock debug text (use 2 for that)
+export sixdesklogdir=""
+export sixdesklevel=1
+export sixdeskhome="."
+export sixdeskecho="yes!"
+
+if [ ! -s ${SixDeskDev}/dot_profile ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_profile is missing!!!"
+    exit 1
+fi
+
+if [ ! -s ${SixDeskDev}/dot_scan ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_scan is missing!!!"
+    exit 1
+fi
+
+
+sixdeskmessleveldef=0
+sixdeskmesslevel=$sixdeskmessleveldef
+
+# - load environment
+source ${SixDeskDev}/dot_profile
+source ${SixDeskDev}/dot_scan
+
+kinit -R
+
+
+
+
+function how_to_use() {
+    cat <<EOF
+   `basename $0` [action] [option]
+    Executes correct_cases for a set of studies defined in scan_definitions.
+EOF
+}
+
+
+
+# get the arguments
+# correct_cases doesn't take any arguments for the moment, but let's keep the framework allowing for arguments
+# we never know...
+
+args=$@
+echo "${args}"
+
+
+
+function doCommand(){
+    echo "running command" ${1}
+    ${1}
+}
+
+
+function run_correct_cases(){
+    doCommand "${SixDeskDev}/correct_cases"
+}
+
+
+if [ "${args}" = "-h" ]; then
+    how_to_use
+    exit 0
+fi
+
+
+scan_loop run_correct_cases
+
+
+exit

--- a/utilities/bash/scan_make_input.sh
+++ b/utilities/bash/scan_make_input.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+
+### INITIALIZATION
+
+source ./scan_definitions
+source ./sixdeskenv
+#source $SixDeskDev/dot_profile
+
+# ------------------------------------------------------------------------------
+# preparatory steps
+# ------------------------------------------------------------------------------
+
+export sixdeskhostname=`hostname`
+export sixdeskname=`basename $0`
+export sixdeskroot=`basename $PWD`
+export sixdeskwhere=`dirname $PWD`
+# Set up some temporary values until we execute sixdeskenv/sysenv
+# Don't issue lock/unlock debug text (use 2 for that)
+export sixdesklogdir=""
+export sixdesklevel=1
+export sixdeskhome="."
+export sixdeskecho="yes!"
+if [ ! -s ${SixDeskDev}/dot_profile ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_profile is missing!!!"
+    exit 1
+fi
+
+if [ ! -s ${SixDeskDev}/dot_scan ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_scan is missing!!!"
+    exit 1
+fi
+
+sixdeskmessleveldef=0
+sixdeskmesslevel=$sixdeskmessleveldef
+
+# - load environment
+source ${SixDeskDev}/dot_profile
+source ${SixDeskDev}/dot_scan
+
+kinit -R
+
+
+function how_to_use() {
+    cat <<EOF
+   `basename $0` [action] [option]
+    performs actions on the input preparation for a defined set of studies
+
+    actions
+    -s      submit MAD jobs for all studies to HTCondor
+    -c      check the progress of the MAD-X studies
+    -w      submit wrong seeds for all studies (requires to run -c beforehand)
+    -U      unlock the directories required to run the script for all studies
+    -M      create the mask files for all studies without any additional action
+
+    options
+    -A      (additional) arguments for mad6t
+              e.g. `basename $0` -s -A "-o 2" will execute mad6t.sh -s -o 2
+              alternatively the same functionality can be obtained with
+                   `basename $0` -A "-s -o 2"
+
+EOF
+}
+
+
+
+
+
+
+
+function generate_mask_file(){
+
+    local _val
+    local _j
+    local _placeholders=(${scan_placeholders})
+    local _placeholder
+    local _
+    local _tmpmask="mask/${scan_prefix}_temp.mask"
+
+    cp mask/${scan_prefix}.mask ${_tmpmask}              # copy mask template to other name to be working on
+
+    mask_vals=${mask_values[i]:2}                      # read the mask variable values for the particular studies
+
+    IFS='%' read -a values <<< "${mask_vals}"          # split the string
+
+    _j=0
+    for _ in ${values[@]}; do                          # replace the individual placeholders in the tmp mask file
+
+	_placeholder=${_placeholders[${_j}]}           # the placeholder to be substituted in the mask file
+	_val=${values[${_j}]}                          # the value this placeholder shall be replaced with
+
+
+	if ${do_placeholder_check}; then                            # check if all placeholders are existing in mask file
+	    check_mask_for_placeholder ${_placeholder} ${_tmpmask}
+	fi
+
+	sed -i "s/${_placeholder}/${_val}/g" ${_tmpmask}
+
+	((_j++))
+    done
+
+    sixdeskmess -1 "Generated mask file: ${study}.mask"
+    mv ${_tmpmask} mask/${study}.mask                  # move tmp mask file to definite name
+
+
+}
+
+
+function check_mask_for_placeholder(){
+    local _placeholder=${1}
+    local _tmpmask=${2}
+
+
+    if ! grep -q "${_placeholder}" "${_tmpmask}"; then
+
+	sixdeskmess -1 "WARNING: Placeholder ${_placeholder} not found in raw mask file ${_tmpmask}!"
+	sixdeskmess -1 "Continue? [y/n]"
+	mask_integrity_error_message
+    fi
+}
+
+
+
+function mask_integrity_error_message(){
+	read answer
+	case ${answer} in
+	    [yY] | [yY][Ee][Ss] )
+		sixdeskmess -1 "Continuing..."
+		do_placeholder_check=false
+                ;;
+
+	    [nN] | [n|N][O|o] )
+                sixdeskmess -1  "Interrupted, please modify mask file or check scan_definitions";
+                exit 1
+                ;;
+	    *) sixdeskmess -1 "Invalid input"
+	       ;;
+	esac
+}
+
+
+function doCommand(){
+    echo "running command" ${1}
+    ${1}
+}
+
+
+function runmad6t(){
+    _cmnd="${SixDeskDev}/mad6t.sh"
+
+    # this part could be done in getopts but it's clearer to do it here
+    if ${lsubmit}; then
+	_cmnd="${_cmnd} -s"
+    elif ${lcheck}; then
+	_cmnd="${_cmnd} -c"
+    elif ${lwrongseeds}; then
+	_cmnd="${_cmnd} -w"
+    elif ${lunlock}; then
+	_cmnd="${_cmnd} -U"
+    fi
+
+    if ${laddargs}; then
+	_cmnd="${_cmnd} ${addargs}"
+    fi
+
+    doCommand "${_cmnd}"
+
+}
+
+
+
+
+lcreatemask=false
+lsubmit=false
+lrerun=false
+lcheck=false
+laddargs=false
+addargs=""
+lwrongseeds=false
+lunlock=false
+
+do_placeholder_check=true
+
+
+while getopts  "hrmcMpsA:wU" opt ; do
+    case $opt in
+	s)
+	    lsubmit=true
+	    ;;
+	c)
+	    lcheck=true
+	    ;;
+	U)
+	    lunlock=true
+	    ;;
+	w)
+	    lwrongseeds=true
+	    ;;
+	m)  findmissing=true
+	    ;;
+	M)  lcreatemask=true
+	    ;;
+	A)
+	    laddargs=true
+	    addargs=${OPTARG}
+	    ;;
+	h)
+	    how_to_use
+	    exit 1
+	    ;;
+	:)
+	    how_to_use
+	    echo "Option -$OPTARG requires an argument."
+	    exit 1
+	    ;;
+	\?)
+	    how_to_use
+	    echo "Invalid option: -$OPTARG"
+	    exit 1
+	    ;;
+    esac
+done
+shift "$(($OPTIND - 1))"
+
+
+if ! ${lsubmit} && ! ${lcreatemask} && ! ${lrerun} && ! ${lcheck} && ! ${laddargs} && ! ${lunlock} && ! ${lwrongseeds}; then
+    sixdeskmess -1 "ERROR: no action specified"
+    how_to_use
+    exit 1
+fi
+
+
+if ${lcreatemask}; then
+    sixdeskmess 1 "Creating mask file"
+    scan_loop generate_mask_file
+fi
+
+
+if ${lsubmit} || ${laddargs}; then
+    scan_loop generate_mask_file
+    scan_loop runmad6t
+fi
+
+if ${lcheck} || ${lwrongseeds} || ${lunlock}; then
+    scan_loop runmad6t
+fi
+
+
+
+
+
+
+exit

--- a/utilities/bash/scan_run_results
+++ b/utilities/bash/scan_run_results
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+source ./scan_definitions
+source ./sixdeskenv
+
+
+# ------------------------------------------------------------------------------
+# preparatory steps
+# ------------------------------------------------------------------------------
+
+export sixdeskhostname=`hostname`
+export sixdeskname=`basename $0`
+export sixdeskroot=`basename $PWD`
+export sixdeskwhere=`dirname $PWD`
+# Set up some temporary values until we execute sixdeskenv/sysenv
+# Don't issue lock/unlock debug text (use 2 for that)
+export sixdesklogdir=""
+export sixdesklevel=1
+export sixdeskhome="."
+export sixdeskecho="yes!"
+
+if [ ! -s ${SixDeskDev}/dot_profile ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_profile is missing!!!"
+    exit 1
+fi
+
+if [ ! -s ${SixDeskDev}/dot_scan ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_scan is missing!!!"
+    exit 1
+fi
+
+
+sixdeskmessleveldef=0
+sixdeskmesslevel=$sixdeskmessleveldef
+
+# - load environment
+source ${SixDeskDev}/dot_profile
+source ${SixDeskDev}/dot_scan
+
+kinit -R 
+
+
+
+
+function how_to_use() {
+    cat <<EOF
+   `basename $0` [action] [option]
+    perform actions and options for a set of studies. actions and options identical to those of run_results:
+EOF
+
+    ${SixDeskDev}/run_results -h 
+}
+
+
+
+# get the arguments
+
+args=$@
+echo "${args}"
+
+
+
+function doCommand(){
+    echo "running command" ${1}
+    ${1}
+}
+
+
+function run_run_results(){
+    doCommand "${SixDeskDev}/run_results ${args}"
+}
+
+
+
+
+if [ "${args}" = "-h" ]; then
+    how_to_use
+    exit 0
+fi
+
+
+
+
+scan_loop run_run_results
+
+
+
+
+
+
+exit
+
+
+

--- a/utilities/bash/scan_run_six.sh
+++ b/utilities/bash/scan_run_six.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+source ./scan_definitions
+source ./sixdeskenv
+
+
+# ------------------------------------------------------------------------------
+# preparatory steps
+# ------------------------------------------------------------------------------
+
+export sixdeskhostname=`hostname`
+export sixdeskname=`basename $0`
+export sixdeskroot=`basename $PWD`
+export sixdeskwhere=`dirname $PWD`
+# Set up some temporary values until we execute sixdeskenv/sysenv
+# Don't issue lock/unlock debug text (use 2 for that)
+export sixdesklogdir=""
+export sixdesklevel=1
+export sixdeskhome="."
+export sixdeskecho="yes!"
+
+if [ ! -s ${SixDeskDev}/dot_profile ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_profile is missing!!!"
+    exit 1
+fi
+
+if [ ! -s ${SixDeskDev}/dot_scan ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_scan is missing!!!"
+    exit 1
+fi
+
+
+sixdeskmessleveldef=0
+sixdeskmesslevel=$sixdeskmessleveldef
+
+# - load environment
+source ${SixDeskDev}/dot_profile
+source ${SixDeskDev}/dot_scan
+
+kinit -R 
+
+
+
+
+function how_to_use() {
+    cat <<EOF
+   `basename $0` [action] [option]
+    perform actions and options for a set of studies. actions and options identical to those of run_six.sh:
+EOF
+
+    ${SixDeskDev}/run_six.sh -h 
+}
+
+
+
+# get the arguments
+
+args=$@
+echo "${args}"
+
+
+
+function doCommand(){
+    echo "running command" ${1}
+    ${1}
+}
+
+
+function run_run_six(){
+    doCommand "${SixDeskDev}/run_six.sh ${args}"
+}
+
+
+
+
+if [ "${args}" = "-h" ]; then
+    how_to_use
+    exit 0
+fi
+
+
+
+
+scan_loop run_run_six
+
+
+
+
+
+
+exit
+
+
+

--- a/utilities/bash/scan_run_status
+++ b/utilities/bash/scan_run_status
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+source ./scan_definitions
+source ./sixdeskenv
+
+
+# ------------------------------------------------------------------------------
+# preparatory steps
+# ------------------------------------------------------------------------------
+
+export sixdeskhostname=`hostname`
+export sixdeskname=`basename $0`
+export sixdeskroot=`basename $PWD`
+export sixdeskwhere=`dirname $PWD`
+# Set up some temporary values until we execute sixdeskenv/sysenv
+# Don't issue lock/unlock debug text (use 2 for that)
+export sixdesklogdir=""
+export sixdesklevel=1
+export sixdeskhome="."
+export sixdeskecho="yes!"
+
+if [ ! -s ${SixDeskDev}/dot_profile ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_profile is missing!!!"
+    exit 1
+fi
+
+if [ ! -s ${SixDeskDev}/dot_scan ] ; then
+    echo "${SixDeskDev}"
+    echo "dot_scan is missing!!!"
+    exit 1
+fi
+
+
+sixdeskmessleveldef=0
+sixdeskmesslevel=$sixdeskmessleveldef
+
+# - load environment
+source ${SixDeskDev}/dot_profile
+source ${SixDeskDev}/dot_scan
+
+kinit -R 
+
+
+
+
+function how_to_use() {
+    cat <<EOF
+   `basename $0` [action] [option]
+    Executes run_status for a set of studies defined in scan_definitions.
+EOF
+}
+
+
+
+# get the arguments
+# run_status doesn't take any arguments for the moment, but let's keep the framework allowing for arguments
+# we never know...
+
+args=$@
+echo "${args}"
+
+
+
+function doCommand(){
+    echo "running command" ${1}
+    ${1}
+}
+
+
+function run_run_status(){
+    doCommand "${SixDeskDev}/run_status ${args}"
+}
+
+
+
+
+if [ "${args}" = "-h" ]; then
+    how_to_use
+    exit 0
+fi
+
+
+
+
+scan_loop run_run_status
+
+
+
+
+
+
+exit
+
+
+

--- a/utilities/templates/input/scan_definitions
+++ b/utilities/templates/input/scan_definitions
@@ -1,0 +1,52 @@
+
+#!/bin/sh
+
+#################
+## Definitions ##
+#################
+
+
+
+export SixDeskDev="/afs/cern.ch/work/p/phermes/private/development/SixDesk/utilities/bash/"
+
+
+
+############################## SCAN OVER A CARTESIAN GRID ################################
+
+# specify the variable names to be used in naming the studies
+scan_variables="QP IOCT"
+
+
+# specify the placeholders in the mask file
+scan_placeholders="%QPV %OCV"                 
+
+
+# specify the prefix of the study name
+# e.g. if the base mask file is called ats2017_b1.mask, we use:
+
+scan_prefix="ats2017_b1"                            
+
+
+# specify the values to be taken by the different variables
+# if we want to use 14 for QP and values between 0 and 40 in steps of 40 for IOCT:
+
+scan_vals_QP="14"
+scan_vals_IOCT=$(seq 0 4 40)
+
+
+############################## SCAN OVER SPECIFIC MASKS  ################################
+
+# THIS OPTION REQUIRES THE MASK FILES TO BE EXISTING
+
+scan_masks=false                                        # (de)activate the scan over specific masks
+scan_studies="
+ats2017_QP_0_IOCT_12
+ats2017_QP_0_IOCT_16
+"
+
+
+
+
+
+
+


### PR DESCRIPTION
## Introduction 
New scripts to perform external scans over a set of independent sixdesk studies. They permit to have a 1:1 relationship between MADX and SixTrack, i.e. knobs defined in MADX are exported correctly to SixTrack. The sole modification of the sixdeskenv the replacement of the study name. The sysenv stays untouched. The set of studies is specified in the new input file 

    scan_definitions 

An example is given in the template directory.  Two options are available to specify the set of studies

1. **Scan over a Cartesian grid of an arbitrary number of variables** with given steps for each variable. 
2. **Scan over preset study names** (which must exist beforehand, including the sysenv/sixdeskenv/.mask

## Cartesian grid
For the first option, the Cartesian grid, the variable names used in the mask files are specified, automatically replaced and the new mask files created. The user defines the parameters of the Cartesian grid and the range of values that should be covered by each. In each new study, the same template .mask file is copied and modified according to the requirements of the user. The parameter names must match actual variables in the .mask file. The variable names to use in the mask file are set in the scan_definitions file. 

The naming convention can be selected, but a general pattern is foreseen. Say, for example, that we want to study the DA for beam 1 and beam 4 with different chromaticities 0, 2 and 4. We specify the variable names to be used in the filename (and study name) in the `scan_definitions` file by 

    scan_variables="B QP"

where we applied the name B for beam and QP for the chromaticity. A template mask file must be existing in the mask directory. The name of the template mask file is specfied via the command:

    scan_prefix="HLLHC_inj"

In this example, the template mask file would be named HLLHC_inj.mask. To specify the placeholders used in the template mask file, we might use 

    scan_placeholders="%BV  %QPV"

but the naming of the variables is fully decided by the user. The script preparing the input will check if the placeholders exist in the template mask file and ask the user for confirmation if they don't exist. 

Finally, we have to specify the values the variables should take. The syntax to scan over B1 and B4 for the chromaticity values 0 2 4 is as follows:

    scan_vals_B="1 4"
    scan_vals_QP="0 2 4"

The scan_make_input.sh script will produce the studies (and their corresponding mask files):

    HLLHC_inj_B_1_QP_0
    HLLHC_inj_B_1_QP_2
    HLLHC_inj_B_1_QP_4
    HLLHC_inj_B_4_QP_0
    HLLHC_inj_B_4_QP_2
    HLLHC_inj_B_4_QP_4

## Specify specific study names

If the user has already produced the required mask files and wants to scan over a specific (sub)set of studies, he can also specify the study names explicitly. This can be useful if we want to run a command for only a subset of a larger set of studies of the Cartesian scan. To use this option, the variable `scan_masks` has to be set to true:

    scan_masks=true

The study names are then given via the variable `scan_studies`, for example:

    scan_studies="HLLHC_inj_B_1_QP_4  HLLHC_inj_B_4_QP_0"

## Usage

The typical work flow of a set of studies is very similar to that of a single study. Here the example for a Cartesian scan:

1. Prepare the template mask file and replace the parameters to be scanned over by the appropriate placeholders. This can be tune, beam (B1/B2/B4), chromaticity, octupole current...
2. Prepare `sixdeskenv` as usual. 
3. Prepare the `scan_definitions` and provide the `scan_variables`, `scan_placeholders`, `scan_prefix`, `scan_vals` (the latter for each of the scan_variables).  
4. Generate the mask files (replacing the scan variables by their individual values) and run MAD-X using `scan_make_input.sh -s`.
5. Submit the SixTrack jobs to BOINC or HTCondor `scan_run_six.sh -a`.
6. Retrieve the results using `scan_run_results`.
7. Run missing jobs on HTCondor `scan_run_six.sh -i`.
8. Correct database and get run status `scan_run_status`

Note that the .mask and `sixdeskenv` file shall be in the usual location. The `scan_definitions` file 


 ## Technical comments
The scan functionalities provide the possibility for external scans. Hence, each step in scan corresponds to an independent study which can also be handled with the standard tools. Each study possesses its own tree in the `tracks` directory. The `sysenv` is not modified. The `sixdeskenv` is only modified to replace the study name. For the latter no specific template or studyname must be used. The parameters in the sixdeskenv can not be changed by the external scan, so it is not possible to loop over energies (e.g. inj/col).  

The options of all scan scripts are identical to those in the underlying scripts. Only `scan_make_input.sh` has an additional option (-M) to create the mask files for all studies without any additional action. They will be stored in the usual directory. 